### PR TITLE
inline requirements from submodule

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
--r submodules/srs/requirements.txt
+Unidecode==0.04.9
+beautifulsoup4==4.1.3
+dumptruck==0.1.6
+html5lib==0.90  # used by beautifulsoup4
+requests==1.0.4  # used by srs.vendor.reppy


### PR DESCRIPTION
With the fixes to morph.io's handling of symbolic links and this pull request this should get your scraper working with buildpacks. If you're happy merging this, then please do that! When you've done that then I'll reenable buildpacks for you.